### PR TITLE
Improve efficiency in creating xsv body.

### DIFF
--- a/gody/format.go
+++ b/gody/format.go
@@ -65,6 +65,15 @@ func toXsv(target FormatTarget, delimiter string) {
 		w.Flush()
 	}
 
+	body := createBody(target, head)
+
+	for _, b := range body {
+		w.Write(b)
+		w.Flush()
+	}
+}
+
+func deprecatedCreateBody(target FormatTarget, head []string) [][]string {
 	var (
 		body [][]string
 	)
@@ -82,11 +91,26 @@ func toXsv(target FormatTarget, delimiter string) {
 		body = append(body, bodyUnit)
 		bodyUnit = []string{}
 	}
+	return body
+}
 
-	for _, b := range body {
-		w.Write(b)
-		w.Flush()
+func createBody(target FormatTarget, head []string) [][]string {
+	body := make([][]string, 0, len(target.ddbresult))
+	const emptySymbol = "_"
+
+	for _, v := range target.ddbresult {
+		bodyUnit := make([]string, 0, len(head))
+		for _, h := range head {
+			// 存在しないキーの場合は、値を"_"にする
+			if _, ok := v[h]; ok {
+				bodyUnit = append(bodyUnit, fmt.Sprint(v[h]))
+			} else {
+				bodyUnit = append(bodyUnit, emptySymbol)
+			}
+		}
+		body = append(body, bodyUnit)
 	}
+	return body
 }
 
 func toJSON(target FormatTarget) {

--- a/gody/format_test.go
+++ b/gody/format_test.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/spf13/cobra"
+	"reflect"
 	"strings"
 	"testing"
 )
 
 func TestFormat(t *testing.T) {
-	m := map[string]interface{}{"jan": "4937751121103", "name": "つぼキーク", "price": 2000}
-	var marr []map[string]interface{}
-	marr = append(marr, m)
+	marr := getTestFormatTargetDdbResult()
 	cmd := new(cobra.Command)
 
 	var formatTarget1 = FormatTarget{
@@ -67,5 +66,62 @@ func TestFormat(t *testing.T) {
 		if c.want != lineOne {
 			t.Errorf("unexpected response: want:%+v, get:%+v", c.want, get)
 		}
+	}
+}
+
+func getTestFormatTargetDdbResult() []map[string]interface{} {
+	var ddbResult []map[string]interface{}
+	m := map[string]interface{}{"jan": "4937751121103", "name": "つぼキーク", "price": 2000}
+	ddbResult = append(ddbResult, m)
+	return ddbResult
+}
+
+func getTestFormatTarget(ddbResult []map[string]interface{}) FormatTarget {
+	cmd := new(cobra.Command)
+	target := FormatTarget{
+		ddbresult: ddbResult,
+		header:    true,
+		format:    "json",
+		fields:    []string{"name", "jan"},
+		cmd:       cmd,
+	}
+	return target
+}
+
+var testCreateBodyExpectedResult = [][]string{{"つぼキーク", "4937751121103"}}
+
+func Test_createBody(t *testing.T) {
+	target := getTestFormatTarget(getTestFormatTargetDdbResult())
+	head := []string{"name", "jan"}
+	body := createBody(target, head)
+	if !reflect.DeepEqual(body, testCreateBodyExpectedResult) {
+		t.Errorf("expected: %s, actual: %s", testCreateBodyExpectedResult, body)
+	}
+}
+
+func Test_deprecatedCreateBody(t *testing.T) {
+	target := getTestFormatTarget(getTestFormatTargetDdbResult())
+	head := []string{"name", "jan"}
+	body := deprecatedCreateBody(target, head)
+	if !reflect.DeepEqual(body, testCreateBodyExpectedResult) {
+		t.Errorf("expected: %s, actual: %s", testCreateBodyExpectedResult, body)
+	}
+}
+
+func Benchmark_deprecatedCreateBody(b *testing.B) {
+	target := getTestFormatTarget(getTestFormatTargetDdbResult())
+	head := []string{"name", "jan"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		deprecatedCreateBody(target, head)
+	}
+}
+
+func Benchmark_createBody(b *testing.B) {
+	target := getTestFormatTarget(getTestFormatTargetDdbResult())
+	head := []string{"name", "jan"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		createBody(target, head)
 	}
 }


### PR DESCRIPTION
benchmark results.

```
Benchmark_deprecatedCreateBody-4   	 3000000	       393 ns/op	     112 B/op	       5 allocs/op
BenchmarkCreateBody-4              	 5000000	       282 ns/op	      96 B/op	       4 allocs/op
```

less memory allocation 😄 